### PR TITLE
Added base implementation for gg run command

### DIFF
--- a/gg/commands/cmd_run.py
+++ b/gg/commands/cmd_run.py
@@ -1,0 +1,21 @@
+import click, requests
+from gg.db import list_from_db
+from gg.cli import pass_context
+
+
+@click.command("run", short_help="Run a scraper")
+@click.option("--n", nargs=1, required=True, type=str)
+@pass_context
+def cli(ctx, n):
+    search = "Finding scraper {} from list of registered scrapers..."
+    ctx.log(search.format(n))
+
+    try:
+        scraper = next(filter(lambda scraper: scraper["name"] == n, list_from_db()))
+        ctx.log("Scraper {} found!".format(n))
+    except StopIteration:
+        ctx.log("Scraper {} not found.".format(n))
+        return
+
+    contents = requests.get(scraper["routes"]["Routes"]).text
+    ctx.log(contents)


### PR DESCRIPTION
Resolves #52 
**WIP - do not merge**
- Implemented a base implementation of `gg run`. This runs on the `routes` endpoint, and not the `data` endpoint, because there's some issue with the scrapers currently deployed.
- The results are printed to console and not written to the mLabs mongo endpoint.

To do:
- Switch implementation to run on `data` endpoint.
- Write to endpoint not just print to console.
