### PR TITLE
Change data route to conform to standard

### DIFF
--- a/microservices/scraper-australia/app/routes.py
+++ b/microservices/scraper-australia/app/routes.py
@@ -12,7 +12,6 @@ def routes_availible():
     )
 
 
-
 @app.route("/test")
 def test():
     return json.dumps(get_one_nonprofit(), indent=4, separators=(",", ": "))

--- a/microservices/scraper_ngolist/app/routes.py
+++ b/microservices/scraper_ngolist/app/routes.py
@@ -4,7 +4,7 @@ from app.scraper import country_page_scrape
 import json
 
 
-@app.route("/scrape_all")
+@app.route("/data")
 def scrape_all_ngos():
     return str(basepage_scrape())
 


### PR DESCRIPTION
Resolves a small issue with an incorrect routes name.

The data route was named "scrape-all" instead of "data" which prevents it from being registered to cli tool. This must be changed for this scraper to be registered to the db.
